### PR TITLE
Add missing RuntimePlatform enum

### DIFF
--- a/unitypack/enums.py
+++ b/unitypack/enums.py
@@ -23,6 +23,7 @@ class RuntimePlatform(IntEnum):
 	OSXWebPlayer = 3
 	OSXDashboardPlayer = 4
 	WindowsWebPlayer = 5
+	WiiPlayer = 6
 	WindowsEditor = 7
 	IPhonePlayer = 8
 	PS3 = 9


### PR DESCRIPTION
Source: Decompiled UnityEngine DLL
```csharp
// UnityEngine.RuntimePlatform
public enum RuntimePlatform
{
	OSXEditor,
	OSXPlayer,
	WindowsPlayer,
	OSXWebPlayer,
	OSXDashboardPlayer,
	WindowsWebPlayer,
	WiiPlayer,
	WindowsEditor
}
```

Fixes some assetbundles (namely from FusionFall Heroes and Adventure Time Battle Party) not opening - more than likely they set this flag to 6 by mistake when building the bundle.