### PR TITLE
Fix a few bugs with import_audio

### DIFF
--- a/unitypack/modding.py
+++ b/unitypack/modding.py
@@ -10,12 +10,17 @@ from .engine.mesh import SubMesh
 def import_audio(obj, audiopath, length, name=None, freq=44100):
 	if not isinstance(obj, Object):
 		raise ValueError('Invalid target object')
+	if not audiopath.endswith(".ogg"):
+		raise ValueError('Only OGG Vorbis is supported')
 
 	with open(audiopath, 'rb') as f:
 		obj.audio_data = f.read()
-	obj.size = len(obj.audio_data)
 	obj.length = length # in seconds; float
 	obj.frequency = freq
+
+	obj._obj['m_Format'] = 5
+	obj._obj['m_DecompressOnLoad'] = True
+	obj._obj['m_Size'] = len(obj.audio_data)
 
 	if name is not None:
 		obj.name = name


### PR DESCRIPTION
I noticed when trying to create a new AudioClip object, using import_audio on it caused exceptions.

This is likely due to `m_DecompressOnLoad` and `m_Format` not being set (`format` is not a property of the AudioClip class). The size property also didn't seem to be getting set, there is one in StreamedResource but I'm not sure if that's used in our code so I replaced it with a more direct `_obj['m_Size']`. 

Tested and works when both replacing existing AudioClips, and adding new AudioClips.