### PR TITLE
Provide an option to automatically determine audio length for importing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Pillow
 fsb5
 lz4
+tinytag
 wand

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
 	fsb5
 	lz4
 	Pillow
+	tinytag
 	wand
 
 [options.package_data]

--- a/unitypack/modding.py
+++ b/unitypack/modding.py
@@ -7,11 +7,20 @@ from .engine.object import Object
 from .engine.mesh import SubMesh
 
 
-def import_audio(obj, audiopath, length, name=None, freq=44100):
+def import_audio(obj, audiopath, length=None, name=None, freq=44100):
 	if not isinstance(obj, Object):
 		raise ValueError('Invalid target object')
 	if not audiopath.endswith(".ogg"):
 		raise ValueError('Only OGG Vorbis is supported')
+
+	if length is None:
+		try:
+			from tinytag import TinyTag
+			tag = TinyTag.get(audiopath)
+			length = tag.duration
+			freq = tag.samplerate
+		except ImportError:
+			raise ValueError('You must specify a length or install tinytag to automatically determine it')
 
 	with open(audiopath, 'rb') as f:
 		obj.audio_data = f.read()

--- a/unitypack/modding.py
+++ b/unitypack/modding.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from tinytag import TinyTag
 from wand.image import Image
 
 from .utils import BinaryWriter
@@ -7,20 +8,18 @@ from .engine.object import Object
 from .engine.mesh import SubMesh
 
 
-def import_audio(obj, audiopath, length=None, name=None, freq=44100):
+def import_audio(obj, audiopath, length=None, name=None, freq=None):
 	if not isinstance(obj, Object):
 		raise ValueError('Invalid target object')
 	if not audiopath.endswith(".ogg"):
 		raise ValueError('Only OGG Vorbis is supported')
 
+
+	tag = TinyTag.get(audiopath)
 	if length is None:
-		try:
-			from tinytag import TinyTag
-			tag = TinyTag.get(audiopath)
-			length = tag.duration
-			freq = tag.samplerate
-		except ImportError:
-			raise ValueError('You must specify a length or install tinytag to automatically determine it')
+		length = tag.duration
+	if freq is None:
+		freq = tag.samplerate
 
 	with open(audiopath, 'rb') as f:
 		obj.audio_data = f.read()


### PR DESCRIPTION
Introduces tinytag as an optional dependency - if you don't have it installed and don't specify a length, it will throw an exception. Importing with a specified length works the same as before. 
Also automatically grab the file's sample rate, since tinytag provides it.