### PR TITLE
add2ab(): Automatically add preload for single objects and provide argument for passing preloads for multi-object assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ unitypack.egg-info/
 __pycache__/
 *.pyc
 graph.dot
+.idea

--- a/unitypack/asset.py
+++ b/unitypack/asset.py
@@ -257,23 +257,31 @@ class Asset:
 
 		return obj
 
-	def add2ab(self, path, path_id, file_id=0):
+	def add2ab(self, path, path_id, file_id=0, preloads=None):
 		"Add a path -> ObjectPointer connection into the AssetBundle object"
 
 		if self.objects[1].type != 'AssetBundle':
 			raise ValueError('AssetBundle object not found. Is this a Scene bundle?')
 
 		ab = self.objects[1].contents
-		ab_index = len(ab['m_Container'])
 		preload_index = len(ab['m_PreloadTable'])
 
 		ptr = ObjectPointer(None, self) # type argument is unused
 		ptr.file_id = file_id
 		ptr.path_id = path_id
 
+		if preloads is None:
+			# assume that this is a single object preload, and add it to the table
+			# TODO: maybe we could also auto collect dependencies for gameobjects, etc.?
+			preload_size = 1
+			ab['m_PreloadTable'].append(ptr)
+		else:
+			preload_size = len(preloads)
+			ab['m_PreloadTable'] = ab['m_PreloadTable'] + preloads
+
 		abdata = FFOrderedDict()
 		abdata['preloadIndex'] = preload_index
-		abdata['preloadSize'] = 1
+		abdata['preloadSize'] = preload_size
 		abdata['asset'] = ptr
 
 		ret = (path, abdata)


### PR DESCRIPTION
- Previously, when using Asset.add2ab(), preload index and size would be specified, but no preload pointer would be added to the table. This has been addressed in this PR in two ways: 
  - When adding a single object (e.g. via the old invocation), a single preload pointer will be added automatically.
  - For multi-object assets, a new argument is available to provide the preload list that will then appended to the table.
- Add .gitignore for PyCharm IDE